### PR TITLE
Add in tested integrations for backdrop and stagecraft endpoints

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "secretAccessKey": ""
   },
   "stagecraft": {
-    "bearer": "b124884c2716359541f92c0104255dea19b23ddcc4d6feea2fbaeaa9aceaa02a",
+    "bearer": "",
     "baseUrl": "https://stagecraft.production.performance.service.gov.uk/"
   }
 }

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "secretAccessKey": ""
   },
   "stagecraft": {
-    "bearer": "",
+    "bearer": "b124884c2716359541f92c0104255dea19b23ddcc4d6feea2fbaeaa9aceaa02a",
     "baseUrl": "https://stagecraft.production.performance.service.gov.uk/"
   }
 }

--- a/config.json
+++ b/config.json
@@ -9,5 +9,6 @@
   "stagecraft": {
     "bearer": "",
     "baseUrl": "https://stagecraft.production.performance.service.gov.uk/"
-  }
+  },
+  "safeMode": true
 }

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -1,16 +1,18 @@
 var log = require('../lib/logger'),
     nodemailer = require('nodemailer'),
-    ses = require('nodemailer-ses-transport'),
     config = require('../config');
 
+var transport = config.safeMode ?
+  require('nodemailer-stub-transport') : require('nodemailer-ses-transport');
+
 function Emailer() {
-  this.transporter = nodemailer.createTransport(ses({
+  this.transporter = nodemailer.createTransport(transport({
     accessKeyId: config.amazonAWS.accessKeyId,
     secretAccessKey: config.amazonAWS.secretAccessKey
   }));
 }
 
-Emailer.prototype.send = function (emailConfig) {
+Emailer.prototype.send = function (emailConfig, callback) {
   log.email('Emailing: ', emailConfig.to, 'Subject: ', emailConfig.subject);
 
   this.transporter.sendMail({
@@ -18,7 +20,7 @@ Emailer.prototype.send = function (emailConfig) {
     to: emailConfig.to,
     subject: emailConfig.subject,
     text: emailConfig.text
-  });
+  }, callback);
 };
 
 module.exports = Emailer;

--- a/lib/emailer.js
+++ b/lib/emailer.js
@@ -12,8 +12,14 @@ function Emailer() {
   }));
 }
 
-Emailer.prototype.send = function (emailConfig, callback) {
+Emailer.prototype.send = function (emailConfig) {
   log.email('Emailing: ', emailConfig.to, 'Subject: ', emailConfig.subject);
+  var callback = config.safeMode ?
+    function (err, info) {
+      if (!err) {
+        log.info('email sent', info.response.toString());
+      }
+    } : function () {};
 
   this.transporter.sendMail({
     from: config.notificationsEmail,

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var email = new (require('./emailer'))(),
   backdrop = new (require('./integrations/backdrop'))(),
   stagecraft = new (require('./integrations/stagecraft'))(),
   message = new (require('./message'))(),
+  logger = require('./logger'),
   Q = require('q'),
   queue = [];
 
@@ -20,12 +21,15 @@ backdrop.getDataSets().then(function (data) {
 
   // When all the email queries are finished, send some notifications
   return Q.all(queue).then( function (dataSets) {
-    console.log(dataSets);
     dataSets.forEach( function (dataSet) {
       email.send({
         to: dataSet.emails.toString(),
         subject: 'Datasets out of date',
         text: dataSet.message
+      }, function (err, info) {
+        if (!err) {
+          logger.info('email sent', info.response.toString());
+        }
       });
     });
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,9 @@ backdrop.getDataSets().then(function (data) {
   // console.log('datasets', data);
   // Got some datasets, now find emails for them
   data.data_sets.forEach( function (dataSet) {
-    console.log('this dataSet', dataSet);
+
     // Set email message
-    // dataSet.message = message.dataSetReminder(dataSet);
+    dataSet.message = message.dataSetReminder(dataSet);
 
     // Queue up email query for this dataset
     queue.push(stagecraft.queryEmail(dataSet));
@@ -29,7 +29,7 @@ backdrop.getDataSets().then(function (data) {
   });
 }).fail(function (err) {
   throw err;
-});
+}).done();
 
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,36 @@
 var email = new (require('./emailer'))(),
   backdrop = new (require('./integrations/backdrop'))(),
-  config = require('../config');
+  stagecraft = new (require('./integrations/stagecraft'))(),
+  message = new (require('./message'))(),
+  Q = require('q'),
+  queue = [];
 
+// Query backdrop for out of date datasets
 backdrop.getDataSets().then(function (data) {
-  email.send({
-    to: config.notificationsEmail,
-    subject: 'Datasets out of date',
-    text: 'There are ' + data.message + '\n\n' + JSON.stringify(data.data_sets)
+  // console.log('datasets', data);
+  // Got some datasets, now find emails for them
+  data.data_sets.forEach( function (dataSet) {
+    console.log('this dataSet', dataSet);
+    // Set email message
+    // dataSet.message = message.dataSetReminder(dataSet);
+
+    // Queue up email query for this dataset
+    queue.push(stagecraft.queryEmail(dataSet));
   });
+
+  // When all the email queries are finished, send some notifications
+  return Q.all(queue).then( function (dataSets) {
+    console.log(dataSets);
+    // email.send({
+    //   to: config.notificationsEmail,
+    //   subject: 'Datasets out of date',
+    //   text: 'There are ' + data.message + '\n\n' + JSON.stringify(data.data_sets)
+    // });
+  });
+}).fail(function (err) {
+  throw err;
 });
+
+
+
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@ var email = new (require('./emailer'))(),
   backdrop = new (require('./integrations/backdrop'))(),
   stagecraft = new (require('./integrations/stagecraft'))(),
   message = new (require('./message'))(),
-  logger = require('./logger'),
   Q = require('q'),
   queue = [];
 
@@ -26,17 +25,9 @@ backdrop.getDataSets().then(function (data) {
         to: dataSet.emails.toString(),
         subject: 'Datasets out of date',
         text: dataSet.message
-      }, function (err, info) {
-        if (!err) {
-          logger.info('email sent', info.response.toString());
-        }
       });
     });
   });
 }).fail(function (err) {
   throw err;
 }).done();
-
-
-
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,11 +21,13 @@ backdrop.getDataSets().then(function (data) {
   // When all the email queries are finished, send some notifications
   return Q.all(queue).then( function (dataSets) {
     console.log(dataSets);
-    // email.send({
-    //   to: config.notificationsEmail,
-    //   subject: 'Datasets out of date',
-    //   text: 'There are ' + data.message + '\n\n' + JSON.stringify(data.data_sets)
-    // });
+    dataSets.forEach( function (dataSet) {
+      email.send({
+        to: dataSet.emails.toString(),
+        subject: 'Datasets out of date',
+        text: dataSet.message
+      });
+    });
   });
 }).fail(function (err) {
   throw err;

--- a/lib/integrations/stagecraft.js
+++ b/lib/integrations/stagecraft.js
@@ -49,7 +49,7 @@ module.exports = Stagecraft;
 //       sets[dataSet.name] = dataSet;
 
 //       // set the data set message (move to a module)
-//       sets[dataSet.name].message = message.datasetReminder(dataSet);
+//       sets[dataSet.name].message = message.dataSetReminder(dataSet);
 //       log.info('Querying stagecraft for ' + 'data-sets/' + dataSet.name + '/users');
 //       promiseQ.push(stagecraft.get('data-sets/' + dataSet.name + '/users', options)
 //         .then(function (emails) {

--- a/lib/integrations/stagecraft.js
+++ b/lib/integrations/stagecraft.js
@@ -1,7 +1,7 @@
 var _ = require('underscore'),
-  log = require('../../logger'),
-  Query = require('../../querist'),
-  message = require('../../message'),
+  log = require('../logger'),
+  Query = require('../querist'),
+  message = require('../message'),
   appConfig = require('../../config');
 
 
@@ -26,7 +26,12 @@ Stagecraft.prototype.queryEmail = function (dataSet) {
 
   return client.get('data-sets/' + dataSet.name + '/users', this.config)
     .then( function (data) {
-      dataSet['emails'] = data;
+      if (data.length) {
+        dataSet.emails = data;
+      } else {
+        log.warn('No emails found for ' + dataSet.name);
+        dataSet['emails'] = appConfig.notificationsEmail;
+      }
       return dataSet;
     });
 

--- a/lib/integrations/stagecraft.js
+++ b/lib/integrations/stagecraft.js
@@ -1,7 +1,6 @@
 var _ = require('underscore'),
   log = require('../logger'),
   Query = require('../querist'),
-  message = require('../message'),
   appConfig = require('../../config');
 
 
@@ -27,7 +26,8 @@ Stagecraft.prototype.queryEmail = function (dataSet) {
   return client.get('data-sets/' + dataSet.name + '/users', this.config)
     .then( function (data) {
       if (data.length) {
-        dataSet.emails = data;
+        log.info('Found', dataSet.emails, 'for', dataSet.name);
+        dataSet.emails = _.pluck(data, 'email');
       } else {
         log.warn('No emails found for ' + dataSet.name);
         dataSet['emails'] = appConfig.notificationsEmail;

--- a/lib/integrations/stagecraft.js
+++ b/lib/integrations/stagecraft.js
@@ -26,8 +26,8 @@ Stagecraft.prototype.queryEmail = function (dataSet) {
   return client.get('data-sets/' + dataSet.name + '/users', this.config)
     .then( function (data) {
       if (data.length) {
-        log.info('Found', dataSet.emails, 'for', dataSet.name);
         dataSet.emails = _.pluck(data, 'email');
+        log.info('Found', dataSet.emails, 'for', dataSet.name);
       } else {
         log.warn('No emails found for ' + dataSet.name);
         dataSet['emails'] = appConfig.notificationsEmail;

--- a/lib/integrations/stagecraft.js
+++ b/lib/integrations/stagecraft.js
@@ -1,0 +1,73 @@
+var _ = require('underscore'),
+  log = require('../../logger'),
+  Query = require('../../querist'),
+  message = require('../../message'),
+  appConfig = require('../../config');
+
+
+function Stagecraft(options) {
+
+  var defaults = {
+    baseUrl : 'https://stagecraft.production.performance.service.gov.uk/',
+    auth: {
+      bearer: appConfig.stagecraft.bearer
+    }
+  };
+
+  this.config = _.extend({}, defaults, options);
+
+}
+
+Stagecraft.prototype.queryEmail = function (dataSet) {
+
+  var client = new Query({
+    baseUrl: this.config.baseUrl
+  });
+
+  return client.get('data-sets/' + dataSet.name + '/users', this.config)
+    .then( function (data) {
+      dataSet['emails'] = data;
+      return dataSet;
+    });
+
+};
+
+
+
+module.exports = Stagecraft;
+
+// var promiseQ = [],
+
+
+//   if (body && body.data_sets) {
+//     _.each(body.data_sets, function (dataSet) {
+//       sets[dataSet.name] = dataSet;
+
+//       // set the data set message (move to a module)
+//       sets[dataSet.name].message = message.datasetReminder(dataSet);
+//       log.info('Querying stagecraft for ' + 'data-sets/' + dataSet.name + '/users');
+//       promiseQ.push(stagecraft.get('data-sets/' + dataSet.name + '/users', options)
+//         .then(function (emails) {
+//           if (emails.length) {
+//             sets[dataSet.name].emails = emails;
+//           }
+//         }).fail(function (err) {
+//           throw err;
+//         }));
+//     });
+//   }
+//   return Q.all(promiseQ);
+// }).then(function () {
+//   _.each(sets, function (dataSet) {
+//     if (dataSet.emails) {
+//       email.send({
+//         // to: dataSet.emails.toString(),
+//         to: config.notificationsEmail,
+//         subject: 'NOTIFICATION: ' + dataSet.name + ' is out of date',
+//         text: dataSet.message
+//       });
+//     }
+//   });
+// }).fail(function (err) {
+//   throw err;
+// }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,12 +6,14 @@ var winston = require('winston'),
       info: 0,
       request: 1,
       email: 2,
-      error: 3
+      warn: 3,
+      error: 4
     },
     colors = {
       info: 'green',
       request: 'blue',
       email: 'magenta',
+      warn: 'yellow',
       error: 'red'
     };
 

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,7 +1,8 @@
 var _ = require('underscore'),
   moment = require('moment');
 
-function messages(options) {
+function Messages(options) {
+
   var defaults = {
     dateFormat : 'Do MMM YY'
   };
@@ -9,7 +10,8 @@ function messages(options) {
   this.config = _.extend({}, defaults, options);
 }
 
-messages.prototype.datasetReminder = function (dataSet, options) {
+Messages.prototype.dataSetReminder = function (dataSet, options) {
+
 
   this.config = _.extend({}, this.config, options);
 
@@ -38,4 +40,4 @@ messages.prototype.datasetReminder = function (dataSet, options) {
 
 };
 
-module.exports = messages;
+module.exports = Messages;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Government Digital Service",
   "dependencies": {
     "moment": "2.8.1",
-    "nodemailer": "1.1.1",
+    "nodemailer": "1.2.1",
     "nodemailer-ses-transport": "1.1.0",
     "nodemailer-stub-transport": "0.1.4",
     "q": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "moment": "2.8.1",
     "nodemailer": "1.1.1",
     "nodemailer-ses-transport": "1.1.0",
+    "nodemailer-stub-transport": "0.1.4",
     "q": "1.0.1",
     "request": "2.40.0",
     "underscore": "1.6.0",

--- a/test/fixtures/stagecraft-emails.json
+++ b/test/fixtures/stagecraft-emails.json
@@ -1,0 +1,26 @@
+[
+ {
+  "email": "hi.pal@email.gsi.govemail"
+ },
+ {
+  "email": "hi.there@somemail.gsi.gov-email"
+ },
+ {
+  "email": "hi.bruv@email.gsi.gov.email"
+ },
+ {
+  "email": "hi.m8@email.cabinet-officeemail.uk"
+ },
+ {
+  "email": "hi.lol@email.gsi.govemail"
+ },
+ {
+  "email": "whatever.bruv@email.gsi.govemail"
+ },
+ {
+  "email": "hi.pal@email.gsi.govemail"
+ },
+ {
+  "email": "hi.there@email.gsi.govemail"
+ }
+]

--- a/test/integrations/backdrop.spec.js
+++ b/test/integrations/backdrop.spec.js
@@ -39,6 +39,10 @@ describe('Backdrop integration', function () {
       return backdrop.getDataSets()
         .then(function (response) {
 
+          Query.prototype.get.should.be.calledOnce;
+          Query.prototype.get.getCall(0).args[0]
+            .should.equal('/_status/data-sets/');
+
           response.should.be.an.instanceOf(Object);
           response.should.have.property('data_sets').
               and.be.instanceOf(Array);

--- a/test/integrations/stagecraft.spec.js
+++ b/test/integrations/stagecraft.spec.js
@@ -58,7 +58,7 @@ describe('Stagecraft integration', function () {
           response.emails.should.be.an.instanceOf(Array);
           response.should.have.property('name');
           response.name.should.equal('testSet');
-          response.emails[0].should.have.property('email');
+          response.emails[0].should.equal('hi.pal@email.gsi.govemail');
         });
     });
 

--- a/test/integrations/stagecraft.spec.js
+++ b/test/integrations/stagecraft.spec.js
@@ -1,0 +1,79 @@
+var backdropResponse = require('../fixtures/backdrop-datasets.json'),
+  Q = require('q');
+
+describe('Backdrop integration', function () {
+  var deferred,
+    Backdrop,
+    Query = require('../../lib/querist');
+
+  beforeEach(function () {
+    deferred = Q.defer();
+    sinon.stub(Query.prototype, 'get').returns(deferred.promise);
+    Backdrop = require('../../lib/integrations/backdrop');
+  });
+
+  afterEach(function () {
+    Query.prototype.get.restore();
+  });
+
+  it('should accept options', function () {
+    var backdrop = new Backdrop({
+      foo: 'bar'
+    });
+
+    backdrop.config.should.eql({
+      baseUrl : 'https://www.performance.service.gov.uk',
+      foo: 'bar'
+    });
+
+  });
+
+  describe('Querying for out of date datasets', function () {
+
+    it('Should respond correctly to datasets', function () {
+
+      var backdrop = new Backdrop();
+
+      deferred.resolve(backdropResponse);
+
+      return backdrop.getDataSets()
+        .then(function (response) {
+
+          response.should.be.an.instanceOf(Object);
+          response.should.have.property('data_sets').
+              and.be.instanceOf(Array);
+          response.should.have.property('data_sets').
+              length(4);
+          response.should.have.property('message').
+              equal('4 data-sets are out of date');
+          response.should.have.property('status').
+              equal('not okay');
+        });
+    });
+
+    it('Should respond correctly with no datasets', function () {
+
+      var backdrop = new Backdrop();
+
+      deferred.resolve(
+        {
+          'data_sets': [],
+          'message': 'all clear',
+          'status': 'okay'
+        }
+      );
+
+      return backdrop.getDataSets()
+        .then(function (response) {
+          response.should.be.an.instanceOf(Object);
+          response.should.have.property('data_sets').
+              and.be.instanceOf(Array);
+          response.should.have.property('data_sets').
+              length(0);
+          response.should.have.property('status').equal('okay');
+        });
+    });
+
+  });
+
+});

--- a/test/message.spec.js
+++ b/test/message.spec.js
@@ -40,7 +40,7 @@ describe('Message <Formats>', function () {
 
       var message = new Message();
 
-      var reminder = message.datasetReminder(dataSet);
+      var reminder = message.dataSetReminder(dataSet);
 
       reminder.should.contain(
         'The data set deposit_foreign_marriage_journey was last updated on 16th Jan 14'
@@ -58,13 +58,13 @@ describe('Message <Formats>', function () {
 
       var message = new Message();
 
-      message.datasetReminder(dataSet, {
+      message.dataSetReminder(dataSet, {
         dateFormat: 'MMMM Do YYYY, h:mm:ss a'
       }).should.contain(
         'January 16th 2014, 4:33:04 pm'
       );
 
-      message.datasetReminder(dataSet, {
+      message.dataSetReminder(dataSet, {
         dateFormat: 'YYYY-MM-DD HH:mm'
       }).should.contain(
         '2014-01-16 16:33'


### PR DESCRIPTION
- add nodemailer stubs and saftey catch `safeMode` so that we can mock sending emails to a list
- fixes an issue with promises in which the absence of a `.done()` state swallows all error messaging
