### PR TITLE
Ensure that queryEmail always returns an array.

### DIFF
--- a/lib/integrations/stagecraft.js
+++ b/lib/integrations/stagecraft.js
@@ -31,7 +31,7 @@ Stagecraft.prototype.queryEmail = function (dataSet) {
         log.info('Found', emails, 'for', dataSet.name);
       } else {
         log.warn('No emails found for ' + dataSet.name);
-        emails = appConfig.notificationsEmail;
+        emails = [appConfig.notificationsEmail];
       }
       return emails;
     });

--- a/test/integrations/stagecraft.spec.js
+++ b/test/integrations/stagecraft.spec.js
@@ -78,7 +78,8 @@ describe('Stagecraft integration', function () {
           Query.prototype.get.should.have.been.calledOnce;
           Query.prototype.get.getCall(0).args[0].should.equal('data-sets/testSet/users');
           Query.prototype.get.getCall(0).args[1].should.eql(config);
-          response.should.equal(appConfig.notificationsEmail);
+          response.should.be.an.instanceOf(Array);
+          response[0].should.equal(appConfig.notificationsEmail);
         });
     });
 


### PR DESCRIPTION
Before it would return an array under some situations and a string under others.
