### PR TITLE
Reduce hourly limit to 58mins

### DIFF
--- a/lib/frequency.js
+++ b/lib/frequency.js
@@ -2,17 +2,17 @@ var _ = require('underscore');
 
 /*
  * Approx timings for how often we should notify
- * 360 (~5mins)      : every hour
- * 4500 (~hourly)    : every hour
- * 90000 (~day)      : every hour
+ * 360 (~5mins)      : every 58mins
+ * 4500 (~hourly)    : every 58mins
+ * 90000 (~day)      : every 58mins
  * 648000 (~week)    : every day
  * 2764800 (~month)  : every other day
  * 8467200 (~quater) : every week
  */
 var frequencyMap = {
-  360: 3600,
-  4500: 3600,
-  90000: 3600,
+  360: 3480,
+  4500: 3480,
+  90000: 3480,
   648000: 86400,
   2764800: 172800,
   8467200: 604800

--- a/test/frequency.spec.js
+++ b/test/frequency.spec.js
@@ -2,17 +2,17 @@ var frequency = require('../lib/frequency');
 
 describe('Frequency', function () {
   it('gets the frequency in the map', function () {
-    frequency(360).should.equal(3600);
-    frequency(4500).should.equal(3600);
-    frequency(90000).should.equal(3600);
+    frequency(360).should.equal(3480);
+    frequency(4500).should.equal(3480);
+    frequency(90000).should.equal(3480);
     frequency(648000).should.equal(86400);
     frequency(2764800).should.equal(172800);
     frequency(8467200).should.equal(604800);
   });
   it('gets the closest frequency in the map', function () {
-    frequency(400).should.equal(3600);
-    frequency(4000).should.equal(3600);
-    frequency(80000).should.equal(3600);
+    frequency(400).should.equal(3480);
+    frequency(4000).should.equal(3480);
+    frequency(80000).should.equal(3480);
     frequency(650000).should.equal(86400);
     frequency(2800000).should.equal(172800);
     frequency(8400000).should.equal(604800);


### PR DESCRIPTION
This is because the cron job runs every hour so the timing is never quite right. If we shift the time to 58mins it will notify on the hour when needed.
