### PR TITLE
Update template to incorporate dashboards

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,16 +18,23 @@ backdrop.getDataSets()
           .then(function (needsEmail) {
             if (needsEmail) {
               //send email
-              return stagecraft.queryEmail(set)
-                .then(function (emails) {
-                  set.recipientCount = emails.length;
-                  return Q.ninvoke(email, 'send', {
-                    // to: emails.toString(),
-                    to: appConfig.emailTestList,
-                    subject: message.generateTitle(set),
-                    text: message.dataSetReminder(set)
-                  });
+              return Q.allSettled([
+                stagecraft.queryEmail(set),
+                stagecraft.dashboardsForDataSet(set)
+              ]).then(function (results) {
+                var emails = results[0].value,
+                    dashboards = results[1].value,
+                    text = message.dataSetReminder(set, dashboards);
+
+                set.recipientCount = emails.length;
+
+                return Q.ninvoke(email, 'send', {
+                  // to: emails.toString(),
+                  to:appConfig.emailTestList,
+                  subject: message.dataSetReminderSubject(set),
+                  text: text
                 });
+              });
             } else {
               log.warn('Skipping data set', set);
               return Q.reject();

--- a/lib/integrations/stagecraft.js
+++ b/lib/integrations/stagecraft.js
@@ -38,6 +38,16 @@ Stagecraft.prototype.queryEmail = function (dataSet) {
 
 };
 
+Stagecraft.prototype.dashboardsForDataSet = function (dataSet) {
+
+  var client = new Query({
+    baseUrl: this.config.baseUrl
+  });
+
+  return client.get('data-sets/' + dataSet.name + '/dashboard', this.config);
+
+};
+
 
 
 module.exports = Stagecraft;

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,82 +1,42 @@
 var _ = require('underscore'),
+  fs = require('fs'),
+  path = require('path'),
+  Mustache = require('mustache'),
   moment = require('moment'),
   appConfig = require('../config');
 
 function Messages(options) {
-
   var defaults = {
     dateFormat : 'DD MMMM YYYY'
   };
 
   this.config = _.extend({}, defaults, options);
+  this.templates = {
+    reminder: fs.readFileSync(
+      path.resolve(__dirname, './templates/reminder.mus')
+    ).toString('utf8'),
+    reminderSubject: 'NOTIFICATION: "{{dataSet.name}}" is OUT OF DATE.'
+  };
 }
 
-
-
-Messages.prototype.dataSetReminder = function (dataSet, options) {
+Messages.prototype.dataSetReminder = function (dataSet, dashboards, options) {
   var config = _.extend({}, this.config, options),
-      lastUpdated = moment(dataSet['last-updated']).utc().format(config.dateFormat),
-      outOfDate = moment(dataSet['last-updated']).utc().add(dataSet['max-age-expected'], 's')
-        .fromNow(true);
+      lastUpdatedRaw = moment(dataSet['last-updated']).utc();
 
-  this.lastUpdated = function () {
-    return [
-      'The data set ',
-      dataSet.name,
-      ' was last updated on ',
-      lastUpdated
-    ].join('');
-  };
-
-  var message = [
-    '\n',
-    '===========================================================',
-    '\n',
-    this.generateTitle(dataSet),
-    '\n',
-    '===========================================================',
-    '\n\n',
-    this.lastUpdated(),
-    ' and is now ',
-    outOfDate,
-    ' out of date.',
-    '\n\n',
-    'Data set: ',
-    dataSet.name,
-    '\n',
-    'Last updated: ',
-    lastUpdated,
-    '\n',
-    'Period out of date: ',
-    outOfDate,
-    '\n',
-    '\n',
-    '===========================================================',
-    '\n',
-    'PLEASE UPLOAD THE DATA AT YOUR EARLIEST CONVENIENCE',
-    '\n',
-    '===========================================================',
-    '\n',
-    '\n',
-    'Login to upload the data at: ',
-    appConfig.adminAppUrl,
-    '\n',
-    '\n',
-    '===========================================================',
-    '\n\n',
-    'This is a notification email from the Performance Platform.',
-    '\n\n',
-    'You have received this email because you requested this notification to be sent to you.',
-    '\n\n',
-    'You can unsubscribe from alerts by sending an email to: ',
-    appConfig.notificationsEmail
-  ].join('');
-
-  return message;
+  return Mustache.render(this.templates.reminder, {
+    dataSet: dataSet,
+    dashboards: dashboards,
+    lastUpdated: lastUpdatedRaw.format(config.dateFormat),
+    outOfDate: lastUpdatedRaw.add(dataSet['max-age-expected'], 's').fromNow(true),
+    adminAppUrl: appConfig.adminAppUrl,
+    notificationsEmail: appConfig.notificationsEmail
+  });
 };
 
-Messages.prototype.generateTitle = function (dataSet) {
-  return 'NOTIFICATION: "' + dataSet.name + '" is OUT OF DATE.';
+Messages.prototype.dataSetReminderSubject = function (dataSet) {
+  return Mustache.render(this.templates.reminderSubject, {
+    dataSet: dataSet
+  });
 };
 
 module.exports = Messages;

--- a/lib/templates/reminder.mus
+++ b/lib/templates/reminder.mus
@@ -1,0 +1,33 @@
+
+
+===========================================================
+
+NOTIFICATION:
+{{#dashboards}}{{{title}}}
+{{/dashboards}}
+
+{{dataSet.name}} dataset is out of date.
+
+===========================================================
+
+
+The data set {{{dataSet.name}}} was last updated on {{{lastUpdated}}} and is now {{{outOfDate}}} out of date.
+
+Data set: {{{dataSet.name}}}
+Last updated: {{{lastUpdated}}}
+Period out of date: {{{outOfDate}}}
+
+===========================================================
+PLEASE UPLOAD THE DATA AT YOUR EARLIEST CONVENIENCE
+===========================================================
+
+Login to upload the data at:
+{{{adminAppUrl}}}
+===========================================================
+
+This is a notification email from the Performance Platform.
+
+You have received this email because you requested this notification to be sent to you.
+
+You can unsubscribe from alerts by sending an email to: {{{notificationsEmail}}}
+

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "Government Digital Service",
   "dependencies": {
     "moment": "2.8.2",
+    "mustache": "0.8.2",
     "nodemailer": "1.2.1",
     "nodemailer-ses-transport": "1.1.0",
     "nodemailer-stub-transport": "0.1.4",

--- a/test/message.spec.js
+++ b/test/message.spec.js
@@ -55,13 +55,13 @@ describe('Message <Formats>', function () {
 
     it('Returns a different date format when passed in', function () {
 
-      message.dataSetReminder(dataSet, {
+      message.dataSetReminder(dataSet, [], {
         dateFormat: 'MMMM Do YYYY, h:mm:ss a'
       }).should.contain(
         'July 18th 2014, 12:00:00 am'
       );
 
-      message.dataSetReminder(dataSet, {
+      message.dataSetReminder(dataSet, [], {
         dateFormat: 'YYYY-MM-DD HH:mm'
       }).should.contain(
         '2014-07-18 00:00'
@@ -70,7 +70,7 @@ describe('Message <Formats>', function () {
     });
 
     it('generates a title', function () {
-      var title = message.generateTitle(dataSet);
+      var title = message.dataSetReminderSubject(dataSet);
 
       title.should.equal('NOTIFICATION: "deposit_foreign_marriage_journey" is OUT OF DATE.');
     });


### PR DESCRIPTION
We want to list the dashboards that a particular data set is used on to
give the end user a little more context that a name that they have never
seen.

In this commit I have switched the Message 'class' over to using
Mustache as the string concat was crazy.
