### PR TITLE
Add entry point for summary email

### DIFF
--- a/lib/frequency.js
+++ b/lib/frequency.js
@@ -2,12 +2,12 @@ var _ = require('underscore');
 
 /*
  * Approx timings for how often we should notify
- * 360 (~5mins)      : every 58mins
- * 4500 (~hourly)    : every 58mins
- * 90000 (~day)      : every 58mins
- * 648000 (~week)    : every day
- * 2764800 (~month)  : every other day
- * 8467200 (~quater) : every week
+ * 360 (~5mins)       : every 58mins
+ * 4500 (~hourly)     : every 58mins
+ * 90000 (~day)       : every 58mins
+ * 648000 (~week)     : every day
+ * 2764800 (~month)   : every other day
+ * 8467200 (~quarter) : every week
  */
 var frequencyMap = {
   360: 3480,

--- a/lib/summaries.js
+++ b/lib/summaries.js
@@ -1,0 +1,13 @@
+var log = require('./logger'),
+    summaryConfig = require('../summaries.json');
+
+log.info('Sending weekly summary email');
+
+for (var i = 0; i < summaryConfig.length; i++) {
+  var dashboardSlug = summaryConfig[i].dashboard;
+  log.info('Creating summary email for ' + dashboardSlug + ' dashboard');
+  for (var j = 0; j < summaryConfig[i].recipients.length; j++) {
+    var recipient = summaryConfig[i].recipients[j];
+    log.info('Sending email to ' + recipient + ' for ' + dashboardSlug + ' dashboard');
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/alphagov/performanceplatform-notifier"
   },
   "scripts": {
-    "start": "node lib/index.js",
+    "out-of-date": "node lib/index.js",
     "summaries": "node lib/summaries.js",
     "unit": "./node_modules/mocha/bin/mocha",
     "test": "npm run-script lint && npm run-script unit;",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "node lib/index.js",
+    "summaries": "node lib/summaries.js",
     "unit": "./node_modules/mocha/bin/mocha",
     "test": "npm run-script lint && npm run-script unit;",
     "lint": "[ -z \"$LINTFILES\" ] && LINTFILES=\"lib/ test/\"; ./node_modules/jshint/bin/jshint ${LINTFILES} && ./node_modules/jscs/bin/jscs ${LINTFILES};"

--- a/summaries.json
+++ b/summaries.json
@@ -1,0 +1,8 @@
+[
+  {
+    "dashboard": "carers-allowance",
+    "recipients": [
+      "example.person@testing.gov.uk"
+    ]
+  }
+]


### PR DESCRIPTION
This commit adds an npm script for `summaries` which currently does nothing other than parse the summary JSON configuration file and log out that it would send email to users.
