### PR TITLE
Add summary email template

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -28,13 +28,14 @@ function Messages(options) {
   };
 }
 
-Messages.prototype.dashboardSummary = function (dashboard) {
+Messages.prototype.dashboardSummary = function (dashboard, modules) {
   return {
     subject: Mustache.render(this.templates.summary.subject, {
       dashboard: dashboard
     }),
     text: Mustache.render(this.templates.summary.text, {
-      dashboard: dashboard
+      dashboard: dashboard,
+      modules: modules
     })
   };
 };

--- a/lib/message.js
+++ b/lib/message.js
@@ -5,6 +5,12 @@ var _ = require('underscore'),
   moment = require('moment'),
   appConfig = require('../config');
 
+function readTemplateSync (templateName) {
+  return fs.readFileSync(
+    path.resolve(__dirname, './templates/' + templateName)
+  ).toString('utf8');
+}
+
 function Messages(options) {
   var defaults = {
     dateFormat : 'DD MMMM YYYY'
@@ -12,9 +18,7 @@ function Messages(options) {
 
   this.config = _.extend({}, defaults, options);
   this.templates = {
-    reminder: fs.readFileSync(
-      path.resolve(__dirname, './templates/reminder.mus')
-    ).toString('utf8'),
+    reminder: readTemplateSync('reminder.mus'),
     reminderSubject: 'NOTIFICATION: "{{dataSet.name}}" is OUT OF DATE.'
   };
 }

--- a/lib/message.js
+++ b/lib/message.js
@@ -19,9 +19,25 @@ function Messages(options) {
   this.config = _.extend({}, defaults, options);
   this.templates = {
     reminder: readTemplateSync('reminder.mus'),
-    reminderSubject: 'NOTIFICATION: "{{dataSet.name}}" is OUT OF DATE.'
+    reminderSubject: 'NOTIFICATION: "{{dataSet.name}}" is OUT OF DATE.',
+
+    summary: {
+      subject: 'Data summary for \'{{{ dashboard.title }}}\' dashboard',
+      text: readTemplateSync('summary.mus')
+    }
   };
 }
+
+Messages.prototype.dashboardSummary = function (dashboard) {
+  return {
+    subject: Mustache.render(this.templates.summary.subject, {
+      dashboard: dashboard
+    }),
+    text: Mustache.render(this.templates.summary.text, {
+      dashboard: dashboard
+    })
+  };
+};
 
 Messages.prototype.dataSetReminder = function (dataSet, dashboards, options) {
   var config = _.extend({}, this.config, options),

--- a/lib/send-summaries.js
+++ b/lib/send-summaries.js
@@ -1,0 +1,3 @@
+var summaries = require('./summaries');
+
+summaries();

--- a/lib/summaries.js
+++ b/lib/summaries.js
@@ -16,8 +16,12 @@ function sendDashboardEmail (config) {
 
   return dashboard.getConfig(config.dashboard).
     then(function (dashboardConfig) {
+      // moduleUpdates is a subset of the modules on dashboardConfig which we
+      // know how to render in an email.
+      var moduleUpdates = [];
+
       var emailSubject = message.dashboardSummary(dashboardConfig).subject,
-          emailText = message.dashboardSummary(dashboardConfig).text;
+          emailText = message.dashboardSummary(dashboardConfig, moduleUpdates).text;
 
       for (var j = 0; j < config.recipients.length; j++) {
         var recipient = config.recipients[j];

--- a/lib/summaries.js
+++ b/lib/summaries.js
@@ -1,13 +1,43 @@
-var log = require('./logger'),
+var Dashboard = require('performanceplatform-client.js'),
+    email = new (require('./emailer'))(require('../blacklist')),
+    log = require('./logger'),
+    message = new (require('./message'))(),
+    Q = require('q'),
     summaryConfig = require('../summaries.json');
 
-log.info('Sending weekly summary email');
-
-for (var i = 0; i < summaryConfig.length; i++) {
-  var dashboardSlug = summaryConfig[i].dashboard;
-  log.info('Creating summary email for ' + dashboardSlug + ' dashboard');
-  for (var j = 0; j < summaryConfig[i].recipients.length; j++) {
-    var recipient = summaryConfig[i].recipients[j];
-    log.info('Sending email to ' + recipient + ' for ' + dashboardSlug + ' dashboard');
+function handleError (err) {
+  if (err) {
+    log.error(err);
   }
 }
+
+function sendDashboardEmail (config) {
+  var dashboard = new Dashboard();
+
+  return dashboard.getConfig(config.dashboard).
+    then(function (dashboardConfig) {
+      var emailSubject = message.dashboardSummary(dashboardConfig).subject,
+          emailText = message.dashboardSummary(dashboardConfig).text;
+
+      for (var j = 0; j < config.recipients.length; j++) {
+        var recipient = config.recipients[j];
+        email.send({
+          'to': [recipient],
+          'subject': emailSubject,
+          'text': emailText
+        }, handleError);
+      }
+
+    }, handleError);
+}
+
+module.exports = function () {
+  var promises = [];
+
+  for (var i = 0; i < summaryConfig.length; i++) {
+    var dashboardSummaryConfig = summaryConfig[i];
+    promises.push(sendDashboardEmail(dashboardSummaryConfig));
+  }
+
+  return Q.all(promises);
+};

--- a/lib/templates/summary.mus
+++ b/lib/templates/summary.mus
@@ -1,1 +1,8 @@
 This is a summary email for {{{ dashboard.title }}}.
+
+{{ #modules }}
+{{ title }}
+-------------------------
+{{ textUpdate }}
+
+{{ /modules }}

--- a/lib/templates/summary.mus
+++ b/lib/templates/summary.mus
@@ -1,0 +1,1 @@
+This is a summary email for {{{ dashboard.title }}}.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "out-of-date": "node lib/index.js",
-    "summaries": "node lib/summaries.js",
+    "summaries": "node lib/send-summaries.js",
     "unit": "./node_modules/mocha/bin/mocha",
     "test": "npm run-script lint && npm run-script unit;",
     "lint": "[ -z \"$LINTFILES\" ] && LINTFILES=\"lib/ test/\"; ./node_modules/jshint/bin/jshint ${LINTFILES} && ./node_modules/jscs/bin/jscs ${LINTFILES};"
@@ -21,6 +21,7 @@
     "nodemailer": "1.2.1",
     "nodemailer-ses-transport": "1.1.0",
     "nodemailer-stub-transport": "0.1.4",
+    "performanceplatform-client.js": "0.0.1",
     "q": "1.0.1",
     "request": "2.40.0",
     "underscore": "1.7.0",

--- a/summaries.json
+++ b/summaries.json
@@ -2,7 +2,14 @@
   {
     "dashboard": "carers-allowance",
     "recipients": [
-      "example.person@testing.gov.uk"
+      "example.person@testing.gov.uk",
+      "another.person@testing.gov.uk"
+    ]
+  },
+  {
+    "dashboard": "tax-disc",
+    "recipients": [
+      "tax.person@testing.gov.uk"
     ]
   }
 ]

--- a/test/summaries.spec.js
+++ b/test/summaries.spec.js
@@ -1,0 +1,36 @@
+var Dashboard = require('performanceplatform-client.js'),
+    Email = require('../lib/emailer'),
+    summaries = require('../lib/summaries'),
+    Q = require('q');
+
+describe('Summary emails', function () {
+
+  var deferred,
+      emailerSendSpy;
+
+  beforeEach(function (done) {
+    deferred = Q.defer();
+
+    sinon.stub(Dashboard.prototype, 'getConfig').returns(deferred.promise);
+    emailerSendSpy = sinon.spy(Email.prototype, 'send');
+
+    summaries().then(function () {
+      done();
+    });
+
+    deferred.resolve({
+      'title': 'Carer\'s allowance applications',
+      'slug': 'carers-allowance',
+      'modules': [ {'x': 'y'}, {'x': 'y'} ]
+    });
+
+  });
+
+  it('should be sent to a user with the correct details', function () {
+    var expectedSubject = 'Data summary for \'Carer\'s allowance applications\' dashboard';
+    sinon.assert.calledOnce(emailerSendSpy);
+    emailerSendSpy.firstCall.args[0].to.should.eql(['example.person@testing.gov.uk']);
+    emailerSendSpy.firstCall.args[0].subject.should.eql(expectedSubject);
+  });
+
+});

--- a/test/summaries.spec.js
+++ b/test/summaries.spec.js
@@ -6,12 +6,13 @@ var Dashboard = require('performanceplatform-client.js'),
 describe('Summary emails', function () {
 
   var deferred,
+      getConfigStub,
       emailerSendSpy;
 
   beforeEach(function (done) {
     deferred = Q.defer();
 
-    sinon.stub(Dashboard.prototype, 'getConfig').returns(deferred.promise);
+    getConfigStub = sinon.stub(Dashboard.prototype, 'getConfig').returns(deferred.promise);
     emailerSendSpy = sinon.spy(Email.prototype, 'send');
 
     summaries().then(function () {
@@ -23,12 +24,19 @@ describe('Summary emails', function () {
       'slug': 'carers-allowance',
       'modules': [ {'x': 'y'}, {'x': 'y'} ]
     });
+  });
 
+  afterEach(function () {
+    getConfigStub.restore();
+    emailerSendSpy.restore();
+  });
+
+  it('should send one email per recipient', function () {
+    sinon.assert.callCount(emailerSendSpy, 3);
   });
 
   it('should be sent to a user with the correct details', function () {
     var expectedSubject = 'Data summary for \'Carer\'s allowance applications\' dashboard';
-    sinon.assert.calledOnce(emailerSendSpy);
     emailerSendSpy.firstCall.args[0].to.should.eql(['example.person@testing.gov.uk']);
     emailerSendSpy.firstCall.args[0].subject.should.eql(expectedSubject);
   });


### PR DESCRIPTION
This pull request:
- Adds a summary email template
- Creates an array `moduleUpdates` which represents modules that we know how to render in an email - it's currently empty
