### PR TITLE
Grouped time series support for summary email

### DIFF
--- a/lib/process-modules.js
+++ b/lib/process-modules.js
@@ -1,8 +1,9 @@
 var _ = require('underscore'),
   Module = require('performanceplatform-client.js').Module,
-  Delta = require('performanceplatform-client.js').Delta;
+  Delta = require('performanceplatform-client.js').Delta,
+  Table = require('performanceplatform-client.js').Table;
 
-function processTimeSeries(timeSeriesData) {
+function processTimeSeries (timeSeriesData) {
   var latestDatum = timeSeriesData[0],
     secondLatestDatum = timeSeriesData[1],
     textUpdate = [];
@@ -26,18 +27,115 @@ function processTimeSeries(timeSeriesData) {
   return textUpdate;
 }
 
-function getTextUpdate(moduleData) {
-  var formattedModule = new Delta(moduleData);
-  return processTimeSeries(formattedModule.data);
+function processGroupedTimeSeries (moduleData) {
+  var textUpdate = [],
+    formattedModule = new Table(moduleData),
+    data = formattedModule.data.reverse(),
+    titleSeries = data.pop(),
+    totalSeries = data[0],
+    latestIdx = titleSeries.length - 1,
+    previousIdx = latestIdx - 1,
+    isLatestDataMissing = false,
+    isPreviousDataMissing = false,
+    isAllLatestDataMissing = true,
+    isAllPreviousDataMissing = true;
+
+  _.each(data, function (series, idx) {
+    var latestVal = series[latestIdx],
+      previousVal = series[previousIdx],
+      latestLine,
+      previousLine;
+
+    textUpdate.push(series[0]); // series title
+    latestLine = titleSeries[latestIdx] + ' = ' + formatValue(latestVal, totalSeries[latestIdx],
+      (idx > 0));
+    previousLine = titleSeries[previousIdx] + ' = ' +
+    formatValue(previousVal, totalSeries[previousIdx], (idx > 0));
+    textUpdate.push(latestLine);
+    textUpdate.push(previousLine);
+    if (isDataPointPresent(latestVal) && (isDataPointPresent(previousVal))) {
+      textUpdate.push('Total change = ' + getPercentageDelta(previousVal, latestVal));
+    } else {
+      if (isDataPointPresent(latestVal)) {
+        isAllLatestDataMissing = false;
+      } else {
+        isLatestDataMissing = true;
+      }
+      if (isDataPointPresent(previousVal)) {
+        isAllPreviousDataMissing = false;
+      } else {
+        isPreviousDataMissing = true;
+      }
+    }
+    textUpdate.push('');
+  });
+  if (!isAllLatestDataMissing || !isAllPreviousDataMissing) {
+    totalsHavePartialData(textUpdate, isLatestDataMissing, isPreviousDataMissing);
+  }
+
+  return textUpdate;
+}
+
+function totalsHavePartialData (textUpdate, isLatestDataMissing, isPreviousDataMissing) {
+  var msg = ' (data is missing)';
+
+  if (isLatestDataMissing) {
+    textUpdate[1] += msg;
+  }
+  if (isPreviousDataMissing) {
+    textUpdate[2] += msg;
+  }
+}
+
+function isDataPointPresent (val) {
+  return !_.contains([undefined, null], val);
+}
+
+function formatValue (val, total, addPercentage) {
+  if (isDataPointPresent(val)) {
+    if (addPercentage) {
+      val += ' (' + getPercentageProportion(val, total) + ' of total)';
+    }
+    return val;
+  } else {
+    return 'no data';
+  }
+}
+
+/*
+ * Calculate the percentage increase / decrease from previous to latest (to 1 decimal place)
+ * eg getPercentageDelta(100, 80) = -20%
+ * getPercentageDelta(100, 150) = 50%
+ */
+function getPercentageDelta (previous, latest) {
+  var diff = latest - previous;
+  return getPercentageProportion(diff, previous);
+}
+
+/*
+ * Calculate the relative proportion of one number to another, as a percentage
+ * eg. getPercentageProportion(5, 20) = 25%;
+ */
+function getPercentageProportion (smaller, larger) {
+  return ((smaller / larger) * 100).toFixed(1) + '%';
+}
+
+function getTextUpdate (moduleData) {
+  var formattedModule;
+  if (moduleData.moduleConfig['module-type'] === 'grouped_timeseries') {
+    return processGroupedTimeSeries(moduleData);
+  } else {
+    formattedModule = new Delta(moduleData);
+    return processTimeSeries(formattedModule.data);
+  }
 }
 
 module.exports = function (modules) {
-  var supported = _.without(Module.prototype.supported, 'grouped_timeseries', 'realtime');
+  var supported = _.without(Module.prototype.supported, 'realtime');
   return _.filter(modules, function (module) {
     if (_.contains(supported, module.moduleConfig['module-type'])) {
       module.textUpdate = getTextUpdate(module);
       return true;
     }
   });
-
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "nodemailer": "1.2.1",
     "nodemailer-ses-transport": "1.1.0",
     "nodemailer-stub-transport": "0.1.4",
-    "performanceplatform-client.js": "git+https://github.com/alphagov/performanceplatform-client.js.git#release_129",
+    "performanceplatform-client.js": "git+https://github.com/alphagov/performanceplatform-client.js.git#release_132",
     "q": "1.0.1",
     "request": "2.40.0",
     "underscore": "1.7.0",

--- a/summaries.json
+++ b/summaries.json
@@ -11,5 +11,11 @@
     "recipients": [
       "tax.person@testing.gov.uk"
     ]
+  },
+  {
+    "dashboard": "prison-visits",
+    "recipients": [
+      "next.person@testing.gov.uk"
+    ]
   }
 ]

--- a/test/process-modules.spec.js
+++ b/test/process-modules.spec.js
@@ -1,52 +1,158 @@
 describe('Process summary modules', function () {
-  var processModules = require('../lib/process-modules.js');
+  var _ = require('underscore'),
+    processModules = require('../lib/process-modules.js'),
+    modules = [];
+  modules.push(require('../node_modules/performanceplatform-client.js' +
+  '/test/fixtures/module-config-kpi.json'));
+  modules.push(require('../node_modules/performanceplatform-client.js' +
+  '/test/fixtures/module-config-single-time-series.json'));
+  modules.push(require('../node_modules/performanceplatform-client.js' +
+  '/test/fixtures/module-config-user-satisfaction-graph.json'));
+  modules.push(require('../node_modules/performanceplatform-client.js' +
+  '/test/fixtures/module-config-grouped-time-series.json'));
 
-  beforeEach(function () {
-    this.dashboardConfig = require('../node_modules/performanceplatform-client.js' +
-    '/test/fixtures/dashboard-response.json');
-    this.dashboardConfig.modules = [];
-    this.dashboardConfig.modules.push(require('../node_modules/performanceplatform-client.js' +
-    '/test/fixtures/module-config-kpi.json'));
-    this.dashboardConfig.modules.push(require('../node_modules/performanceplatform-client.js' +
-    '/test/fixtures/module-config-single-time-series.json'));
-    this.dashboardConfig.modules.push(require('../node_modules/performanceplatform-client.js' +
-    '/test/fixtures/module-config-user-satisfaction-graph.json'));
-    this.processed = processModules(this.dashboardConfig.modules);
+  describe('Complete data', function () {
+
+    beforeEach(function () {
+      this.modules = JSON.parse(JSON.stringify(modules));
+      this.processed = processModules(this.modules);
+    });
+
+    it('returns an array of modules', function () {
+      this.processed.length.should.equal(4);
+    });
+
+    it('should return modules with title property', function () {
+      var module = this.processed[0];
+      module.moduleConfig.title.should.equal('Transactions per year');
+    });
+
+    it('should return a textUpdate for a KPI module', function () {
+      var module = this.processed[0];
+      module.textUpdate.should.eql([
+        '1 July 2013 to 30 June 2014 = 45.8m',
+        '1 April 2013 to 31 March 2014 = 46m',
+        'Total change = −0.27%'
+      ]);
+    });
+
+    it('should return a textUpdate for a single time series module', function () {
+      var module = this.processed[1];
+      module.textUpdate.should.eql([
+        '1 November 2014 to 30 November 2014 = 82.9%',
+        '1 October 2014 to 31 October 2014 = 74.3%',
+        'Total change = +11.57%'
+      ]);
+    });
+
+    it('should return a textUpdate for a user satisfaction module', function () {
+      var module = this.processed[2];
+      module.textUpdate.should.eql([
+        '12 January 2015 to 18 January 2015 = 85.8%',
+        '5 January 2015 to 11 January 2015 = 86.2%',
+        'Total change = −0.46%'
+      ]);
+    });
+
+    it('should return a textUpdate for a grouped time series module', function () {
+      var module = this.processed[3];
+      module.textUpdate.should.eql([
+
+        'Totals',
+        'December 2014 = 3705269',
+        'November 2014 = 3158941',
+        'Total change = 17.3%',
+        '',
+        'DVLA centre',
+        'December 2014 = 13033 (0.4% of total)',
+        'November 2014 = 13720 (0.4% of total)',
+        'Total change = -5.0%',
+        '',
+        'Post Office',
+        'December 2014 = 1062692 (28.7% of total)',
+        'November 2014 = 988061 (31.3% of total)',
+        'Total change = 7.6%',
+        '',
+        'Digital and automated phone',
+        'December 2014 = 2629544 (71.0% of total)',
+        'November 2014 = 2157160 (68.3% of total)',
+        'Total change = 21.9%',
+        ''
+      ]);
+    });
+
   });
 
-  it('returns an array of modules', function () {
-    this.processed.length.should.equal(3);
+  describe('Incomplete data', function () {
+
+    beforeEach(function () {
+      _.each(_.last(modules[3].dataSource.data, 2), function (item) {
+        item['volume:sum'] = null;
+      });
+      this.modules = JSON.parse(JSON.stringify(modules));
+      this.processed = processModules(this.modules);
+    });
+
+    it('should not show percentages for a data point when its missing for grouped time series',
+      function () {
+        var module = this.processed[3];
+        module.textUpdate.should.eql([
+
+          'Totals',
+          'December 2014 = 13033 (data is missing)',
+          'November 2014 = 3158941',
+          'Total change = -99.6%',
+          '',
+          'DVLA centre',
+          'December 2014 = 13033 (100.0% of total)',
+          'November 2014 = 13720 (0.4% of total)',
+          'Total change = -5.0%',
+          '',
+          'Post Office',
+          'December 2014 = no data',
+          'November 2014 = 988061 (31.3% of total)',
+          '',
+          'Digital and automated phone',
+          'December 2014 = no data',
+          'November 2014 = 2157160 (68.3% of total)',
+          ''
+        ]);
+      });
   });
 
-  it('should return modules with title property', function () {
-    var module = this.processed[0];
-    module.moduleConfig.title.should.equal('test');
-  });
+  describe('All data missing', function () {
 
-  it('should return a textUpdate for a KPI module', function () {
-    var module = this.processed[0];
-    module.textUpdate.should.eql([
-      '1 July 2013 to 30 June 2014 = 1',
-      '1 April 2013 to 30 June 2014 = 2',
-      'Total change = −50.00%'
-    ]);
-  });
+    beforeEach(function () {
+      _.each(_.last(modules[3].dataSource.data, 6), function (item) {
+        item['volume:sum'] = null;
+      });
+      this.modules = JSON.parse(JSON.stringify(modules));
+      this.processed = processModules(this.modules);
+    });
 
-  it('should return a textUpdate for a single time series module', function () {
-    var module = this.processed[1];
-    module.textUpdate.should.eql([
-      '1 January 2014 to 31 January 2014 = 78.5%',
-      '1 February 2014 to 28 February 2014 = 78.5%',
-      'Total change = 0%'
-    ]);
-  });
+    it('should not show the totals "data is missing" message when all data is missing' +
+      'for grouped time series',
+      function () {
+        var module = this.processed[3];
+        module.textUpdate.should.eql([
 
-  it('should return a textUpdate for a user satisfaction module', function () {
-    var module = this.processed[2];
-    module.textUpdate.should.eql([
-      '12 January 2015 to 18 January 2015 = 85.8%',
-      '5 January 2015 to 11 January 2015 = 86.2%',
-      'Total change = −0.46%'
-    ]);
+          'Totals',
+          'December 2014 = no data',
+          'November 2014 = no data',
+          '',
+          'DVLA centre',
+          'December 2014 = no data',
+          'November 2014 = no data',
+          '',
+          'Post Office',
+          'December 2014 = no data',
+          'November 2014 = no data',
+          '',
+          'Digital and automated phone',
+          'December 2014 = no data',
+          'November 2014 = no data',
+          ''
+        ]);
+      });
   });
 });

--- a/test/summaries.spec.js
+++ b/test/summaries.spec.js
@@ -1,27 +1,24 @@
-var Dashboard = require('performanceplatform-client.js').Dashboard,
-  Email = require('../lib/emailer'),
-  summaries = require('../lib/summaries'),
-  Q = require('q'),
-  _ = require('underscore');
-
 describe('Summary emails', function () {
+  var Dashboard = require('performanceplatform-client.js').Dashboard,
+    Email = require('../lib/emailer'),
+    summaries = require('../lib/summaries'),
+    Q = require('q'),
+    _ = require('underscore'),
+    dashboardConfig = require('../node_modules/performanceplatform-client.js' +
+    '/test/fixtures/dashboard-response.json');
+
+  dashboardConfig.modules = [];
+  dashboardConfig.modules.push(require('../node_modules/performanceplatform-client.js' +
+    '/test/fixtures/module-config-kpi.json'));
+  dashboardConfig.modules.push(require('../node_modules/performanceplatform-client.js' +
+    '/test/fixtures/module-config-grouped-time-series.json'));
 
   var deferred,
     getConfigStub,
     emailerSendSpy;
 
   beforeEach(function (done) {
-    this.dashboardConfig = require('../node_modules/performanceplatform-client.js' +
-      '/test/fixtures/dashboard-response.json');
-    this.dashboardConfig.modules = [];
-    this.dashboardConfig.modules.push(require('../node_modules/performanceplatform-client.js' +
-    '/test/fixtures/module-config-kpi.json'));
-    this.dashboardConfig.modules.push(require('../node_modules/performanceplatform-client.js' +
-    '/test/fixtures/module-config-grouped-time-series.json'));
-    this.dashboardConfig.modules.push(require('../node_modules/performanceplatform-client.js' +
-    '/test/fixtures/module-config-single-time-series.json'));
-    this.dashboardConfig.modules.push(require('../node_modules/performanceplatform-client.js' +
-    '/test/fixtures/module-config-user-satisfaction-graph.json'));
+    this.dashboardConfig = JSON.parse(JSON.stringify(dashboardConfig));
     deferred = Q.defer();
 
     getConfigStub = sinon
@@ -40,10 +37,11 @@ describe('Summary emails', function () {
   afterEach(function () {
     getConfigStub.restore();
     emailerSendSpy.restore();
+    this.dashboardConfig = null;
   });
 
   it('should send one email per recipient', function () {
-    sinon.assert.callCount(emailerSendSpy, 3);
+    sinon.assert.callCount(emailerSendSpy, 4);
   });
 
   it('should be sent to a user with the correct details', function () {
@@ -53,9 +51,9 @@ describe('Summary emails', function () {
   });
 
   it('should list out module updates', function () {
-    this.firstDashboard.text.should.have.string('1 July 2013 to 30 June 2014');
-    this.firstDashboard.text.should.have.string('1 April 2013 to 30 June 2014');
-    this.firstDashboard.text.should.have.string('Total change = −50.00%');
+    this.firstDashboard.text.should.have.string('1 July 2013 to 30 June 2014 = 45.8m');
+    this.firstDashboard.text.should.have.string('1 April 2013 to 31 March 2014 = 46m');
+    this.firstDashboard.text.should.have.string('Total change = −0.27%');
   });
 
 });


### PR DESCRIPTION
including missing data scenarios
- [if any data is missing, show warning in totals section of summary. Also don't show x% of total message next to missing data point](https://github.com/alphagov/performanceplatform-notifier/compare/grouped-time-series?expand=1#diff-b4fa1a7e4e87ff90da046c266d9775e9R102)
- if all data is missing, don't show those messages, [just show 'no data' next to all data points](https://github.com/alphagov/performanceplatform-notifier/compare/grouped-time-series?expand=1#diff-b4fa1a7e4e87ff90da046c266d9775e9R139)
