### PR TITLE
Add a file to create a crontab

### DIFF
--- a/crontab.js
+++ b/crontab.js
@@ -1,0 +1,29 @@
+require('crontab').load(function(err, crontab) {
+  if (err) {
+    return console.error(err);
+  }
+
+  var job,
+      jobName,
+      notifierPath = '/var/apps/performanceplatform-notifier';
+
+  jobName = 'performanceplatform-notifier_out-of-date';
+
+  crontab.remove({comment: jobName});
+  job = crontab.create('cd ' + notifierPath + ' && npm run-script out-of-date', null, jobName);
+  job.minute().at(0);
+
+  jobName = 'performanceplatform-notifier_summaries';
+
+  crontab.remove({comment: jobName});
+  job = crontab.create('cd ' + notifierPath + ' && npm run-script summaries', null, jobName);
+  job.minute().at(0);
+  job.hour().at(7);
+  job.dow().on(1);
+
+  crontab.save(function(err, crontab) {
+    if (err) {
+      console.log(err);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "main": "",
   "author": "Government Digital Service",
   "dependencies": {
+    "crontab": "1.0.2",
     "moment": "2.8.2",
     "mustache": "0.8.2",
     "nodemailer": "1.2.1",


### PR DESCRIPTION
The `crontab` package will create cron jobs in the user's crontab.

We'd rather define cron jobs in the application than in Puppet.
